### PR TITLE
Improve APIs

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -17,3 +17,8 @@ Compression
 -----------
 
 .. automethod:: brotli.compress
+
+.. autoclass:: brotli.BrotliEncoderMode
+   :members:
+
+.. autodata:: brotli.BROTLI_DEFAULT_MODE

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,9 @@ setup(
     install_requires=[
         "cffi>=1.0.0",
     ],
+    extras_require={
+        ':python_version == "2.7" or python_version == "3.3"': ['enum34>=1.0.4, <2'],
+    },
 
     cffi_modules=["src/brotli/build.py:ffi"],
 

--- a/src/brotli/__init__.py
+++ b/src/brotli/__init__.py
@@ -1,2 +1,4 @@
 # -*- coding: utf-8 -*-
-from .brotli import decompress, Decompressor, compress  # noqa
+from .brotli import (
+    decompress, Decompressor, compress, BrotliEncoderMode, BROTLI_DEFAULT_MODE
+)  # noqa

--- a/src/brotli/__init__.py
+++ b/src/brotli/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# flake8: noqa
 from .brotli import (
     decompress, Decompressor, compress, BrotliEncoderMode, BROTLI_DEFAULT_MODE
-)  # noqa
+)

--- a/src/brotli/brotli.py
+++ b/src/brotli/brotli.py
@@ -8,6 +8,8 @@ from ._brotli import ffi, lib
 class BrotliEncoderMode(enum.IntEnum):
     """
     Compression modes for the Brotli encoder.
+
+    .. versionadded:: 0.5.0
     """
     #: Default compression mode. The compressor does not know anything in
     #: advance about the properties of the input.
@@ -42,6 +44,10 @@ def compress(data,
              dictionary=b''):
     """
     Compress a string using Brotli.
+
+    .. versionchanged:: 0.5.0
+       Added ``mode``, ``quality``, `lgwin``, ``lgblock``, and ``dictionary``
+       parameters.
 
     :param data: A bytestring containing the data to compress.
     :type data: ``bytes``
@@ -128,6 +134,9 @@ class Decompressor(object):
     """
     An object that allows for streaming decompression of Brotli-compressed
     data.
+
+    .. versionchanged:: 0.5.0
+       Added ``dictionary`` parameter.
 
     :param dictionary: A pre-set dictionary for LZ77. Please use this with
         caution: if a dictionary is used for compression, the same dictionary

--- a/src/brotli/brotli.py
+++ b/src/brotli/brotli.py
@@ -74,7 +74,7 @@ def compress(data,
     brotli_encoder = lib.BrotliEncoderCreateInstance(
         ffi.NULL, ffi.NULL, ffi.NULL
     )
-    if not brotli_encoder:
+    if not brotli_encoder:  # pragma: no cover
         raise RuntimeError("Unable to allocate Brotli encoder!")
 
     brotli_encoder = ffi.gc(brotli_encoder, lib.BrotliEncoderDestroyInstance)
@@ -142,9 +142,9 @@ class Decompressor(object):
         self._decoder = ffi.gc(dec, lib.BrotliDecoderDestroyInstance)
 
         if dictionary:
-            self._dictionary = ffi.new("uint_t []", dictionary)
+            self._dictionary = ffi.new("uint8_t []", dictionary)
             self._dictionary_size = len(dictionary)
-            lib.BrotliDecoderSetCustomDictonary(
+            lib.BrotliDecoderSetCustomDictionary(
                 self._decoder,
                 self._dictionary_size,
                 self._dictionary

--- a/src/brotli/build.py
+++ b/src/brotli/build.py
@@ -25,8 +25,6 @@ ffi.cdef("""
     #define BROTLI_FALSE ...
 
     /* dec/state.h */
-    typedef ... BrotliState;
-
     /* Allocating function pointer. Function MUST return 0 in the case of
        failure. Otherwise it MUST return a valid pointer to a memory region of
        at least size length. Neither items nor size are allowed to be 0.
@@ -38,87 +36,89 @@ ffi.cdef("""
        address is 0. */
     typedef void (*brotli_free_func)(void* opaque, void* address);
 
-    /* Creates the instance of BrotliState and initializes it. alloc_func and
-       free_func MUST be both zero or both non-zero. In the case they are both
-       zero, default memory allocators are used. opaque is passed to alloc_func
-       and free_func when they are called. */
-    BrotliState* BrotliCreateState(brotli_alloc_func alloc_func,
-                                   brotli_free_func free_func,
-                                   void* opaque);
-
-    /* Deinitializes and frees BrotliState instance. */
-    void BrotliDestroyState(BrotliState* state);
-
-
     /* dec/decode.h */
 
     typedef enum {
-      /* Decoding error, e.g. corrupt input or no memory */
-      BROTLI_RESULT_ERROR = 0,
-      /* Successfully completely done */
-      BROTLI_RESULT_SUCCESS = 1,
-      /* Partially done, but must be called again with more input */
-      BROTLI_RESULT_NEEDS_MORE_INPUT = 2,
-      /* Partially done, but must be called again with more output */
-      BROTLI_RESULT_NEEDS_MORE_OUTPUT = 3
-    } BrotliResult;
+      /* Decoding error, e.g. corrupt input or memory allocation problem */
+      BROTLI_DECODER_RESULT_ERROR = 0,
+      /* Decoding successfully completed */
+      BROTLI_DECODER_RESULT_SUCCESS = 1,
+      /* Partially done; should be called again with more input */
+      BROTLI_DECODER_RESULT_NEEDS_MORE_INPUT = 2,
+      /* Partially done; should be called again with more output */
+      BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT = 3
+    } BrotliDecoderResult;
 
-    /* Sets *decoded_size to the decompressed size of the given encoded */
-    /* stream. This function only works if the encoded buffer has a single */
-    /* meta block, or if it has two meta-blocks, where the first is */
-    /* uncompressed and the second is empty. */
-    /* Returns 1 on success, 0 on failure. */
-    int BrotliDecompressedSize(size_t encoded_size,
-                               const uint8_t* encoded_buffer,
-                               size_t* decoded_size);
+    typedef enum {...} BrotliDecoderErrorCode;
+    typedef ... BrotliDecoderState;
 
-    /* Decompresses the data in encoded_buffer into decoded_buffer, and sets */
-    /* *decoded_size to the decompressed length. */
-    /* Returns 0 if there was either a bit stream error or memory allocation */
-    /* error, and 1 otherwise. */
-    /* If decoded size is zero, returns 1 and keeps decoded_buffer */
-    /* unchanged. */
-    BrotliResult BrotliDecompressBuffer(size_t encoded_size,
-                                        const uint8_t* encoded_buffer,
-                                        size_t* decoded_size,
-                                        uint8_t* decoded_buffer);
+    /* Creates the instance of BrotliDecoderState and initializes it.
+       |alloc_func| and |free_func| MUST be both zero or both non-zero. In the
+       case they are both zero, default memory allocators are used. |opaque| is
+       passed to |alloc_func| and |free_func| when they are called. */
+    BrotliDecoderState* BrotliDecoderCreateInstance(brotli_alloc_func,
+                                                    brotli_free_func,
+                                                    void *);
+
+    /* Deinitializes and frees BrotliDecoderState instance. */
+    void BrotliDecoderDestroyInstance(BrotliDecoderState* state);
 
     /* Decompresses the data. Supports partial input and output.
-    /*
-    /* Must be called with an allocated input buffer in *next_in and an
-    /* allocated output buffer in *next_out. The values *available_in and
-    /* *available_out must specify the allocated size in *next_in and *next_out
-    /* respectively.
-    /*
-    /* After each call, *available_in will be decremented by the amount of
-    /* input bytes consumed, and the *next_in pointer will be incremented by
-    /* that amount. Similarly, *available_out will be decremented by the amount
-    /* of output bytes written, and the *next_out pointer will be incremented
-    /* by that amount. total_out, if it is not a null-pointer, will be set to
-    /* the number of bytes decompressed since the last state initialization.
-    /*
-    /* Input is never overconsumed, so next_in and available_in could be passed
-    /* to the next consumer after decoding is complete. */
-    BrotliResult BrotliDecompressStream(size_t* available_in,
-                                        const uint8_t** next_in,
-                                        size_t* available_out,
-                                        uint8_t** next_out,
-                                        size_t* total_out,
-                                        BrotliState* s);
+
+       Must be called with an allocated input buffer in |*next_in| and an
+       allocated output buffer in |*next_out|. The values |*available_in| and
+       |*available_out| must specify the allocated size in |*next_in| and
+       |*next_out| respectively.
+
+       After each call, |*available_in| will be decremented by the amount of
+       input bytes consumed, and the |*next_in| pointer will be incremented by
+       that amount. Similarly, |*available_out| will be decremented by the
+       amount of output bytes written, and the |*next_out| pointer will be
+       incremented by that amount. |total_out|, if it is not a null-pointer,
+       will be set to the number of bytes decompressed since the last state
+       initialization.
+
+       Input is never overconsumed, so |next_in| and |available_in| could be
+       passed to the next consumer after decoding is complete. */
+    BrotliDecoderResult BrotliDecoderDecompressStream(BrotliDecoderState* s,
+                                                      size_t* available_in,
+                                                      const uint8_t** next_in,
+                                                      size_t* available_out,
+                                                      uint8_t** next_out,
+                                                      size_t* total_out);
 
     /* Fills the new state with a dictionary for LZ77, warming up the
        ringbuffer, e.g. for custom static dictionaries for data formats.
        Not to be confused with the built-in transformable dictionary of Brotli.
-       The dictionary must exist in memory until decoding is done and is owned
-       by the caller. To use:
-       -initialize state with BrotliStateInit
-       -use BrotliSetCustomDictionary
-       -use BrotliDecompressBufferStreaming
-       -clean up with BrotliStateCleanup
+       |size| should be less or equal to 2^24 (16MiB), otherwise the dictionary
+       will be ignored. The dictionary must exist in memory until decoding is
+       done and is owned by the caller. To use:
+        1) Allocate and initialize state with BrotliCreateInstance
+        2) Use BrotliSetCustomDictionary
+        3) Use BrotliDecompressStream
+        4) Clean up and free state with BrotliDestroyState
     */
-    void BrotliSetCustomDictionary(
-        size_t size, const uint8_t* dict, BrotliState* s);
+    void BrotliDecoderSetCustomDictionary(
+        BrotliDecoderState* s, size_t size, const uint8_t* dict);
 
+    /* Returns true, if decoder has some unconsumed output.
+       Otherwise returns false. */
+    BROTLI_BOOL BrotliDecoderHasMoreOutput(const BrotliDecoderState* s);
+
+    /* Returns true, if decoder has already received some input bytes.
+       Otherwise returns false. */
+    BROTLI_BOOL BrotliDecoderIsUsed(const BrotliDecoderState* s);
+
+    /* Returns true, if decoder is in a state where we reached the end of the
+       input and produced all of the output; returns false otherwise. */
+    BROTLI_BOOL BrotliDecoderIsFinished(const BrotliDecoderState* s);
+
+    /* Returns detailed error code after BrotliDecompressStream returns
+       BROTLI_DECODER_RESULT_ERROR. */
+    BrotliDecoderErrorCode BrotliDecoderGetErrorCode(
+                                                  const BrotliDecoderState* s);
+
+    const char* BrotliDecoderErrorString(BrotliDecoderErrorCode c);
 
     /* enc/encode.h */
     typedef ... BrotliEncoderState;

--- a/test/test_simple_compression.py
+++ b/test/test_simple_compression.py
@@ -26,3 +26,11 @@ def test_roundtrip_compression_with_files(simple_compressed_file):
 @given(binary())
 def test_compressed_data_roundtrips(s):
     assert brotli.decompress(brotli.compress(s)) == s
+
+
+@given(binary(), binary())
+def test_compressed_data_with_dictionaries(s, dictionary):
+    d = brotli.Decompressor(dictionary)
+    compressed = brotli.compress(s, dictionary=dictionary)
+    uncompressed = d.decompress(compressed)
+    assert uncompressed == s


### PR DESCRIPTION
This fixes #35.

This was originally designed to be small in scope as a change, but it turned out that to achieve parity I needed to rewrite most of the internals. That's fairly annoying, but from the perspective of users they shouldn't see any problems at all.