### PR TITLE
Disable hypothesis deadline for slow tests

### DIFF
--- a/test/test_simple_compression.py
+++ b/test/test_simple_compression.py
@@ -9,7 +9,7 @@ import brotli
 
 import pytest
 
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis.strategies import binary, integers, sampled_from, one_of
 
 
@@ -25,6 +25,7 @@ def test_roundtrip_compression_with_files(simple_compressed_file):
     ) == uncompressed_data
 
 
+@settings(deadline=None)
 @given(
     chunk_size=integers(min_value=1, max_value=2**12),
     mode=sampled_from(list(brotli.BrotliEncoderMode)),
@@ -62,6 +63,7 @@ def test_streaming_compression(one_compressed_file,
         assert decompressed == f.read()
 
 
+@settings(deadline=None)
 @given(
     chunk_size=integers(min_value=1, max_value=2**12),
     mode=sampled_from(list(brotli.BrotliEncoderMode)),


### PR DESCRIPTION
test_streaming_compression* tests tend to fail due to hitting default
Hypothesis deadline, e.g.:

    E           DeadlineExceeded: Test took 22501.81ms, which exceeds the deadline of 200.00ms

Disable the deadline for the two tests to get them to pass reliably.