### PR TITLE
build abi3 wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -6,28 +6,29 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python_version: [2.7, 3.5]
+        include:
+        - name: manylinux
+          os: ubuntu-latest
+        - name: macos
+          os: macos-latest
+        - name: win
+          os: windows-latest
 
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
       - uses: actions/setup-python@v2
-        name: Install Python ${{ matrix.python_version }}
-        with:
-          python-version: ${{ matrix.python_version }}
 
       - name: Install cibuildwheel
-        run: |
-          python -m pip install cibuildwheel
+        run: python -m pip install cibuildwheel
       - name: Install Visual C++ for Python 2.7
         if: runner.os == 'Windows'
-        run: |
-          choco install vcpython27 -f -y
+        run: choco install vcpython27 -f -y
       - name: Build wheels
-        run: |
-          python -m cibuildwheel --output-dir wheelhouse
+        run: python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_BUILD: cp27-${{ matrix.name }}* cp35-${{ matrix.name }}* pp*-${{ matrix.name }}*
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python_version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
+        python_version: [2.7, 3.5]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -11,6 +11,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - uses: actions/setup-python@v2
         name: Install Python ${{ matrix.python_version }}
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -31,4 +31,5 @@ jobs:
           CIBW_BUILD: cp27-${{ matrix.name }}* cp35-${{ matrix.name }}* pp*-${{ matrix.name }}*
       - uses: actions/upload-artifact@v2
         with:
+          name: wheels-${{ matrix.name }}
           path: ./wheelhouse/*.whl

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 import os
+import platform
+import sys
 from setuptools import find_packages, setup
 from setuptools.command.build_ext import build_ext
 
@@ -60,6 +62,19 @@ if USE_SHARED_BROTLI != "1":
         }),
     ]
 
+cmdclass = {'build_ext': BuildClibBeforeExt}
+if sys.version_info > (3,) and platform.python_implementation() == "CPython":
+    try:
+        import wheel.bdist_wheel
+    except ImportError:
+        pass
+    else:
+        class BDistWheel(wheel.bdist_wheel.bdist_wheel):
+            def finalize_options(self):
+                self.py_limited_api = "cp3{}".format(sys.version_info[1])
+                wheel.bdist_wheel.bdist_wheel.finalize_options(self)
+        cmdclass['bdist_wheel'] = BDistWheel
+
 setup(
     name="brotlipy",
     version="0.7.0",
@@ -93,9 +108,7 @@ setup(
 
     zip_safe=False,
 
-    cmdclass={
-        'build_ext': BuildClibBeforeExt,
-    },
+    cmdclass=cmdclass,
 
     classifiers=[
         "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
sorry for the drive by, noticed [this tweet](https://twitter.com/sethmlarson/status/1323294753484644355) and figured I could save you some future pain :)

cffi natively builds [abi3](https://www.python.org/dev/peps/pep-3149/)-tagged .so files so this just extends it to the wheels

the neat thing about abi3 is it means you don't need to:
- produce wheels for every version of cpython 3.x
- produce new wheels when a new version of python comes out

this *drastically* reduces the pain when a new version is released as it can just reuse the existing wheels

you'll probably want to change whatever build infra you have to just build the *oldest* version of cpython you support

my PR on this is actually a day early, I've got a video about the specifics of this technique going up tomorrow [on my youtube channel](https://youtube.com/anthonywritescode)

here's an example:

```console
$ virtualenv venv -ppython3.6
created virtual environment CPython3.6.12.final.0-64 in 238ms
  creator CPython3Posix(dest=/tmp/brotlipy/venv, clear=False, global=False)
  seeder FromAppData(download=False, pip=bundle, setuptools=bundle, wheel=bundle, via=copy, app_data_dir=/home/asottile/.local/share/virtualenv)
    added seed packages: pip==20.2.4, setuptools==50.3.2, wheel==0.35.1
  activators BashActivator,CShellActivator,FishActivator,PowerShellActivator,PythonActivator,XonshActivator
$ ./venv/bin/pip wheel . --no-deps
Processing /tmp/brotlipy
Building wheels for collected packages: brotlipy
  Building wheel for brotlipy (setup.py) ... done
  Created wheel for brotlipy: filename=brotlipy-0.7.0-cp36-abi3-linux_x86_64.whl size=1007729 sha256=c56ce8972b973afb724300ed5f416efe04dde4bf167fe4cc8614d2c18720d7f4
  Stored in directory: /tmp/pip-ephem-wheel-cache-tnu52eiq/wheels/f2/e8/0b/cf0d3ca022916c8d034f0d83ed5d7b567f189a7a19de9853f5
Successfully built brotlipy
$ virtualenv venv39 -ppython3.9
created virtual environment CPython3.9.0.final.0-64 in 1241ms
  creator CPython3Posix(dest=/tmp/brotlipy/venv39, clear=False, global=False)
  seeder FromAppData(download=False, pip=bundle, setuptools=bundle, wheel=bundle, via=copy, app_data_dir=/home/asottile/.local/share/virtualenv)
    added seed packages: pip==20.2.4, setuptools==50.3.2, wheel==0.35.1
  activators BashActivator,CShellActivator,FishActivator,PowerShellActivator,PythonActivator,XonshActivator
$ venv39/bin/pip install brotlipy-0.7.0-cp36-abi3-linux_x86_64.whl 
Processing ./brotlipy-0.7.0-cp36-abi3-linux_x86_64.whl
Collecting cffi>=1.0.0
  Downloading cffi-1.14.3-cp39-cp39-manylinux1_x86_64.whl (405 kB)
     |████████████████████████████████| 405 kB 2.3 MB/s 
Collecting pycparser
  Using cached pycparser-2.20-py2.py3-none-any.whl (112 kB)
Installing collected packages: pycparser, cffi, brotlipy
Successfully installed brotlipy-0.7.0 cffi-1.14.3 pycparser-2.20
$ venv39/bin/python -c 'import brotli'
$ 
```

for an example of another package which does this, check out https://github.com/asottile/onigurumacffi