### PR TITLE
Rename package to 'brotlicffi'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
-brotlipy
-========
+BrotliCFFI
+==========
 
-This library contains Python bindings for the reference Brotli encoder/decoder,
+This library contains Python CFFI bindings for the reference Brotli encoder/decoder,
 `available here`_. This allows Python software to use the Brotli compression
 algorithm directly from Python code.
 
@@ -9,8 +9,8 @@ To use it simply, try this:
 
 .. code-block:: python
 
-    import brotli
-    data = brotli.decompress(compressed_data)
+    import brotlicffi
+    data = brotlicffi.decompress(compressed_data)
 
 More information can be found `in the documentation`_.
 
@@ -20,11 +20,12 @@ More information can be found `in the documentation`_.
 License
 -------
 
-The source code of brotlipy is available under the MIT license. Brotli itself
+The source code of BrotliCFFI is available under the MIT license. Brotli itself
 is made available under the Version 2.0 of the Apache Software License. See the
 LICENSE and libbrotli/LICENSE files for more information.
 
 Authors
 -------
 
-brotlipy is maintained by Cory Benfield.
+BrotliCFFI/brotlipy was authored by Cory Benfield and
+is currently maintained by Seth Michael Larson.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -87,9 +87,9 @@ qthelp:
 	@echo
 	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
 	      ".qhcp project file in $(BUILDDIR)/qthelp, like this:"
-	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/brotlipy.qhcp"
+	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/brotlicffi.qhcp"
 	@echo "To view the help file:"
-	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/brotlipy.qhc"
+	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/brotlicffi.qhc"
 
 applehelp:
 	$(SPHINXBUILD) -b applehelp $(ALLSPHINXOPTS) $(BUILDDIR)/applehelp
@@ -104,8 +104,8 @@ devhelp:
 	@echo
 	@echo "Build finished."
 	@echo "To view the help file:"
-	@echo "# mkdir -p $$HOME/.local/share/devhelp/brotlipy"
-	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/brotlipy"
+	@echo "# mkdir -p $$HOME/.local/share/devhelp/brotlicffi"
+	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/brotlicffi"
 	@echo "# devhelp"
 
 epub:

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -127,9 +127,9 @@ if "%1" == "qthelp" (
 	echo.
 	echo.Build finished; now you can run "qcollectiongenerator" with the ^
 .qhcp project file in %BUILDDIR%/qthelp, like this:
-	echo.^> qcollectiongenerator %BUILDDIR%\qthelp\brotlipy.qhcp
+	echo.^> qcollectiongenerator %BUILDDIR%\qthelp\brotlicffi.qhcp
 	echo.To view the help file:
-	echo.^> assistant -collectionFile %BUILDDIR%\qthelp\brotlipy.ghc
+	echo.^> assistant -collectionFile %BUILDDIR%\qthelp\brotlicffi.ghc
 	goto end
 )
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,34 +1,34 @@
 API Documentation
 =================
 
-.. module:: brotli
+.. module:: brotlicffi
 
-This section of the documentation covers the API of brotlipy.
+This section of the documentation covers the API of BrotliCFFI.
 
 Decompression
 -------------
 
-.. automethod:: brotli.decompress
+.. automethod:: brotlicffi.decompress
 
-.. autoclass:: brotli.Decompressor
+.. autoclass:: brotlicffi.Decompressor
   :inherited-members:
 
 Compression
 -----------
 
-.. automethod:: brotli.compress
+.. automethod:: brotlicffi.compress
 
-.. autoclass:: brotli.Compressor
+.. autoclass:: brotlicffi.Compressor
    :members:
 
-.. autoclass:: brotli.BrotliEncoderMode
+.. autoclass:: brotlicffi.BrotliEncoderMode
    :members:
 
-.. autodata:: brotli.BROTLI_DEFAULT_MODE
+.. autodata:: brotlicffi.BROTLI_DEFAULT_MODE
 
 Errors
 ------
 
-.. autoclass:: brotli.Error
+.. autoclass:: brotlicffi.Error
 
-.. autodata:: brotli.error
+.. autodata:: brotlicffi.error

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# brotlipy documentation build configuration file, created by
+# BrotliCFFI documentation build configuration file, created by
 # sphinx-quickstart on Sat Oct  3 16:51:16 2015.
 #
 # This file is execfile()d with the current directory set to its
@@ -12,6 +12,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+import datetime
 import sys
 import os
 import shlex
@@ -49,8 +50,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'brotlipy'
-copyright = u'2015, Cory Benfield'
+project = u'brotlicffi'
+copyright = u'%d, Cory Benfield' % (datetime.date.today().year,)
 author = u'Cory Benfield'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -203,7 +204,7 @@ html_static_path = ['_static']
 #html_search_scorer = 'scorer.js'
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'brotlipydoc'
+htmlhelp_basename = 'BrotliCFFIdoc'
 
 # -- Options for LaTeX output ---------------------------------------------
 
@@ -225,7 +226,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  (master_doc, 'brotlipy.tex', u'brotlipy Documentation',
+  (master_doc, 'BrotliCFFI.tex', u'BrotliCFFI Documentation',
    u'Cory Benfield', 'manual'),
 ]
 
@@ -255,7 +256,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'brotlipy', u'brotlipy Documentation',
+    (master_doc, 'BrotliCFFI', u'BrotliCFFI Documentation',
      [author], 1)
 ]
 
@@ -269,8 +270,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  (master_doc, 'brotlipy', u'brotlipy Documentation',
-   author, 'brotlipy', 'One line description of project.',
+  (master_doc, 'BrotliCFFI', u'BrotliCFFI Documentation',
+   author, 'BrotliCFFI', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,30 +1,30 @@
-Brotlipy: Python Bindings to the Brotli Compression Algorithm
-=============================================================
+BrotliCFFI: Python CFFI Bindings to the Brotli Compression Algorithm
+====================================================================
 
-Brotlipy is a collection of `CFFI-based`_ bindings to the `Brotli`_ compression
+BrotliCFFI is a collection of `CFFI-based`_ bindings to the `Brotli`_ compression
 reference implementation as written by Google. This enables Python software to
 easily and quickly work with the Brotli compression algorithm, regardless of
 what interpreter is being used.
 
-Brotlipy has a very similar interface to the standard library's ``zlib``
-module:
+BrotliCFFI has an identical API to Google's Python C bindings
+for the `Brotli`_ library.
 
 .. code-block:: python
 
-    import brotli
+    import brotlicffi
 
     # Decompress a Brotli-compressed payload in one go.
-    decompressed_data = brotli.decompress(compressed_data)
+    decompressed_data = brotlicffi.decompress(compressed_data)
 
     # Alternatively, you can do incremental decompression.
-    d = brotli.Decompressor()
+    d = brotlicffi.Decompressor()
     for chunk in chunks_of_compressed_data:
         some_uncompressed_data = d.decompress(chunk)
 
     remaining_data = d.flush()
 
     # You can compress data too.
-    compressed = brotli.compress(uncompressed_data)
+    compressed = brotlicffi.compress(uncompressed_data)
 
 For more details on the API, see :doc:`api`.
 
@@ -45,5 +45,5 @@ Documentation
 License
 -------
 
-Brotlipy's source code is made available under the MIT license. Brotli itself
+BrotliCFFI's source code is made available under the MIT license. Brotli itself
 is licensed under Version 2.0 of the Apache Software License.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,11 +1,11 @@
 Installation
 ============
 
-Installing Brotlipy couldn't be easier:
+Installing BrotliCFFI couldn't be easier:
 
 .. code-block:: bash
 
-    $ pip install brotlipy
+    $ python -m pip install brotlicffi
 
 On OS X and Windows this should succeed without difficulty. On Linux, the above
 command has a few dependencies: mostly, you need a C compiler, the Python

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ if USE_SHARED_BROTLI != "1":
             "include_dirs": [
                 "libbrotli/include",
                 "libbrotli/",
-                "src/brotli"
+                "src/brotlicffi"
             ],
             "sources": [
                 'libbrotli/common/dictionary.c',
@@ -76,12 +76,12 @@ if sys.version_info > (3,) and platform.python_implementation() == "CPython":
         cmdclass['bdist_wheel'] = BDistWheel
 
 setup(
-    name="brotlipy",
+    name="brotlicffi",
     version="0.7.0",
 
-    description="Python binding to the Brotli library",
+    description="Python CFFI bindings to the Brotli library",
     long_description=long_description,
-    url="https://github.com/python-hyper/brotlipy/",
+    url="https://github.com/python-hyper/brotlicffi",
     license="MIT",
 
     author="Cory Benfield",
@@ -93,17 +93,10 @@ setup(
     install_requires=[
         "cffi>=1.0.0",
     ],
-    extras_require={
-        ':python_version == "2.7" or python_version == "3.3"': ['enum34>=1.0.4, <2'],
-    },
-
-    cffi_modules=["src/brotli/build.py:ffi"],
-
+    cffi_modules=["src/brotlicffi/_build.py:ffi"],
     packages=find_packages('src'),
     package_dir={'': 'src'},
-
-    ext_package="brotli",
-
+    ext_package="brotlicffi",
     libraries=libraries,
 
     zip_safe=False,
@@ -120,5 +113,8 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ]
 )

--- a/src/brotlicffi/__init__.py
+++ b/src/brotlicffi/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # flake8: noqa
-from .brotli import (
+from ._api import (
     decompress, Decompressor, compress, BrotliEncoderMode, DEFAULT_MODE,
     Compressor, MODE_GENERIC, MODE_TEXT, MODE_FONT, error, Error
 )

--- a/src/brotlicffi/_api.py
+++ b/src/brotlicffi/_api.py
@@ -2,7 +2,7 @@
 import math
 import enum
 
-from ._brotli import ffi, lib
+from ._brotlicffi import ffi, lib
 
 
 class Error(Exception):

--- a/src/brotlicffi/_build.py
+++ b/src/brotlicffi/_build.py
@@ -16,7 +16,7 @@ if 'win32' not in str(sys.platform).lower():
 
 
 ffi.set_source(
-    "_brotli",
+    "_brotlicffi",
     """#include <brotli/decode.h>
        #include <brotli/encode.h>
     """,

--- a/test/test_compatibility.py
+++ b/test/test_compatibility.py
@@ -5,7 +5,7 @@ test_compatibility
 
 Tests for names that exist purely for compatibility purposes.
 """
-import brotli
+import brotlicffi
 
 
 def test_compatible_names():
@@ -13,6 +13,6 @@ def test_compatible_names():
     Encoder modes are also defined as individual top-level names with the same
     names as in brotlimodule.cc from the library.
     """
-    assert brotli.MODE_GENERIC is brotli.BrotliEncoderMode.GENERIC
-    assert brotli.MODE_TEXT is brotli.BrotliEncoderMode.TEXT
-    assert brotli.MODE_FONT is brotli.BrotliEncoderMode.FONT
+    assert brotlicffi.MODE_GENERIC is brotlicffi.BrotliEncoderMode.GENERIC
+    assert brotlicffi.MODE_TEXT is brotlicffi.BrotliEncoderMode.TEXT
+    assert brotlicffi.MODE_FONT is brotlicffi.BrotliEncoderMode.FONT

--- a/test/test_simple_compression.py
+++ b/test/test_simple_compression.py
@@ -5,7 +5,7 @@ test_simple_compression
 
 Tests for compression of single chunks.
 """
-import brotli
+import brotlicffi
 
 import pytest
 
@@ -20,8 +20,8 @@ def test_roundtrip_compression_with_files(simple_compressed_file):
     with open(simple_compressed_file[0], 'rb') as f:
         uncompressed_data = f.read()
 
-    assert brotli.decompress(
-        brotli.compress(uncompressed_data)
+    assert brotlicffi.decompress(
+        brotlicffi.compress(uncompressed_data)
     ) == uncompressed_data
 
 
@@ -29,7 +29,7 @@ def test_roundtrip_compression_with_files(simple_compressed_file):
 @settings(deadline=None)
 @given(
     chunk_size=integers(min_value=1, max_value=2**12),
-    mode=sampled_from(list(brotli.BrotliEncoderMode)),
+    mode=sampled_from(list(brotlicffi.BrotliEncoderMode)),
     quality=integers(min_value=0, max_value=11),
     lgwin=integers(min_value=10, max_value=24),
     lgblock=one_of(
@@ -47,7 +47,7 @@ def test_streaming_compression(one_compressed_file,
     Confirm that the streaming compressor works as expected.
     """
     compressed_chunks = []
-    c = brotli.Compressor(
+    c = brotlicffi.Compressor(
         mode=mode, quality=quality, lgwin=lgwin, lgblock=lgblock
     )
     with open(one_compressed_file, 'rb') as f:
@@ -59,7 +59,7 @@ def test_streaming_compression(one_compressed_file,
             compressed_chunks.append(c.compress(next_data))
 
     compressed_chunks.append(c.finish())
-    decompressed = brotli.decompress(b''.join(compressed_chunks))
+    decompressed = brotlicffi.decompress(b''.join(compressed_chunks))
     with open(one_compressed_file, 'rb') as f:
         assert decompressed == f.read()
 
@@ -68,7 +68,7 @@ def test_streaming_compression(one_compressed_file,
 @settings(deadline=None)
 @given(
     chunk_size=integers(min_value=1, max_value=2**12),
-    mode=sampled_from(list(brotli.BrotliEncoderMode)),
+    mode=sampled_from(list(brotlicffi.BrotliEncoderMode)),
     quality=integers(min_value=0, max_value=11),
     lgwin=integers(min_value=10, max_value=24),
     lgblock=one_of(
@@ -87,7 +87,7 @@ def test_streaming_compression_flush(one_compressed_file,
     after each chunk.
     """
     compressed_chunks = []
-    c = brotli.Compressor(
+    c = brotlicffi.Compressor(
         mode=mode, quality=quality, lgwin=lgwin, lgblock=lgblock
     )
     with open(one_compressed_file, 'rb') as f:
@@ -100,20 +100,20 @@ def test_streaming_compression_flush(one_compressed_file,
             compressed_chunks.append(c.flush())
 
     compressed_chunks.append(c.finish())
-    decompressed = brotli.decompress(b''.join(compressed_chunks))
+    decompressed = brotlicffi.decompress(b''.join(compressed_chunks))
     with open(one_compressed_file, 'rb') as f:
         assert decompressed == f.read()
 
 
 @given(binary())
 def test_compressed_data_roundtrips(s):
-    assert brotli.decompress(brotli.compress(s)) == s
+    assert brotlicffi.decompress(brotlicffi.compress(s)) == s
 
 
 @given(binary(), binary())
 def test_compressed_data_with_dictionaries(s, dictionary):
-    d = brotli.Decompressor(dictionary)
-    compressed = brotli.compress(s, dictionary=dictionary)
+    d = brotlicffi.Decompressor(dictionary)
+    compressed = brotlicffi.compress(s, dictionary=dictionary)
     uncompressed = d.decompress(compressed)
     assert uncompressed == s
 
@@ -127,7 +127,6 @@ def test_compressed_data_with_dictionaries(s, dictionary):
         {"lgblock": 52},
     ]
 )
-@pytest.mark.parametrize("exception_cls", [brotli.Error, brotli.error])
-def test_bad_compressor_parameters(params, exception_cls):
-    with pytest.raises(exception_cls):
-        brotli.Compressor(**params)
+def test_bad_compressor_parameters(params):
+    with pytest.raises(brotlicffi.error):
+        brotlicffi.Compressor(**params)

--- a/test/test_simple_decompression.py
+++ b/test/test_simple_decompression.py
@@ -5,7 +5,7 @@ test_simple_decompression
 
 Tests for decompression of single chunks.
 """
-import brotli
+import brotlicffi
 
 import pytest
 
@@ -20,7 +20,7 @@ def test_decompression(simple_compressed_file):
     with open(simple_compressed_file[1], 'rb') as f:
         compressed_data = f.read()
 
-    assert brotli.decompress(compressed_data) == uncompressed_data
+    assert brotlicffi.decompress(compressed_data) == uncompressed_data
 
 
 def test_decompressobj(simple_compressed_file):
@@ -30,7 +30,7 @@ def test_decompressobj(simple_compressed_file):
     with open(simple_compressed_file[1], 'rb') as f:
         compressed_data = f.read()
 
-    o = brotli.Decompressor()
+    o = brotlicffi.Decompressor()
     data = o.decompress(compressed_data)
     data += o.flush()
     data += o.finish()
@@ -49,7 +49,7 @@ def test_drip_feed(simple_compressed_file):
         compressed_data = f.read()
 
     outdata = []
-    o = brotli.Decompressor()
+    o = brotlicffi.Decompressor()
     for i in range(0, len(compressed_data)):
         outdata.append(o.decompress(compressed_data[i:i+1]))
 
@@ -59,21 +59,21 @@ def test_drip_feed(simple_compressed_file):
     assert b''.join(outdata) == uncompressed_data
 
 
-@pytest.mark.parametrize('exception_cls', [brotli.Error, brotli.error])
+@pytest.mark.parametrize('exception_cls', [brotlicffi.Error, brotlicffi.error])
 def test_streaming_decompression_fails_properly_on_garbage(exception_cls):
     """
     Garbage data properly fails decompression.
     """
-    o = brotli.Decompressor()
+    o = brotlicffi.Decompressor()
     with pytest.raises(exception_cls):
         o.decompress(b'some random garbage')
 
 
-@pytest.mark.parametrize('exception_cls', [brotli.Error, brotli.error])
+@pytest.mark.parametrize('exception_cls', [brotlicffi.Error, brotlicffi.error])
 @pytest.mark.parametrize('bogus', (b'some random garbage', b'bogus'))
 def test_decompression_fails_properly_on_garbage(bogus, exception_cls):
     """
     Garbage data properly fails decompression.
     """
     with pytest.raises(exception_cls):
-        brotli.decompress(bogus)
+        brotlicffi.decompress(bogus)

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py27, py34, py35, py36, py37, py38, py39, pypy, lint
 
 [testenv]
 deps= -r{toxinidir}/test_requirements.txt
-commands= py.test --cov brotli {posargs} {toxinidir}/test/
+commands= py.test --cov brotlicffi {posargs} {toxinidir}/test/
 
 [testenv:pypy]
 # temporarily disable coverage testing on PyPy due to performance problems
@@ -12,4 +12,4 @@ commands= py.test {toxinidir}/test/
 [testenv:lint]
 basepython=python3
 deps = flake8
-commands = flake8 --max-complexity 10 src/brotli test
+commands = flake8 --max-complexity 10 src/brotlicffi test


### PR DESCRIPTION
Closes #145 

Other things:
- The `brotlipy` branch houses the `brotlipy` package which will only receive a 0.8.0 release.
- Once this PR lands I'll rename the GitHub repository to `brotlicffi`
- Will add `__version__` to both `brotlipy` and `brotlicffi` and release a v0.8.0 of each
