### PR TITLE
Add Decompressor.is_finished()

### DIFF
--- a/test/test_simple_decompression.py
+++ b/test/test_simple_decompression.py
@@ -51,10 +51,14 @@ def test_drip_feed(simple_compressed_file):
     outdata = []
     o = brotlicffi.Decompressor()
     for i in range(0, len(compressed_data)):
+        assert not o.is_finished()
         outdata.append(o.decompress(compressed_data[i:i+1]))
 
+    assert o.is_finished()
     outdata.append(o.flush())
+    assert o.is_finished()
     outdata.append(o.finish())
+    assert o.is_finished()
 
     assert b''.join(outdata) == uncompressed_data
 
@@ -67,6 +71,7 @@ def test_streaming_decompression_fails_properly_on_garbage(exception_cls):
     o = brotlicffi.Decompressor()
     with pytest.raises(exception_cls):
         o.decompress(b'some random garbage')
+    assert not o.is_finished()
 
 
 @pytest.mark.parametrize('exception_cls', [brotlicffi.Error, brotlicffi.error])


### PR DESCRIPTION
This puts the API of `brotlicffi.Decompressor` to be the same as `brotli.Decompressor`