### PR TITLE
Test free-threaded Python with pytest-run-parallel

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,4 @@
+hypothesis
 pytest
 pytest-cov
-hypothesis
+pytest-run-parallel

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,8 @@ envlist = py37, py38, py39, py310, py311, py312, pypy, lint
 
 [testenv]
 deps= -r{toxinidir}/test_requirements.txt
-commands= python -bb -m pytest --cov brotlicffi {posargs} {toxinidir}/test/
+commands=
+    python -bb -m pytest --iterations=8 --parallel-threads=auto --cov brotlicffi {posargs} {toxinidir}/test/
 
 [testenv:pypy]
 # temporarily disable coverage testing on PyPy due to performance problems


### PR DESCRIPTION
To be confident about free-threaded compatibility, it is recommended to test with [`pytest-run-parallel`](https://github.com/Quansight-Labs/pytest-run-parallel).
* https://py-free-threading.github.io/testing

Something like:
% `uvx --with=pytest-run-parallel pytest --iterations=8 --parallel-threads=auto`