### PR TITLE
Fix the version number

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-1.2.1.0 (2025-02-23)
+1.2.0.1 (2025-03-05)
 --------------------
 
 - Added support for the free-threaded build of Python 3.14.

--- a/src/brotlicffi/__init__.py
+++ b/src/brotlicffi/__init__.py
@@ -5,4 +5,4 @@ from ._api import (
     Compressor, MODE_GENERIC, MODE_TEXT, MODE_FONT, error, Error
 )
 
-__version__ = "1.2.1.0"
+__version__ = "1.2.0.1"


### PR DESCRIPTION
This should fix the test failure seen on `main`:

```
>           assert brotlicffi.__version__.startswith(
                "%s.%s.%s." % (
                    brotli_versions["MAJOR"],
                    brotli_versions["MINOR"],
                    brotli_versions["PATCH"]
                )
            )
E           AssertionError: assert False
E            +  where False = <built-in method startswith of str object at 0x00000152CB7C7AF0>(('%s.%s.%s.' % ('1', '2', '0')))
E            +    where <built-in method startswith of str object at 0x00000152CB7C7AF0> = '1.2.1.0'.startswith
E            +      where '1.2.1.0' = brotlicffi.__version__
```

I already deleted the `v1.2.1.0` tag.

Let's wait to merge this until CI passes.